### PR TITLE
use the native websocket provided by @polkadot/rpc-provider

### DIFF
--- a/store/incognitee.ts
+++ b/store/incognitee.ts
@@ -28,10 +28,7 @@ export const useIncognitee = defineStore("incognitee", {
         "Initializing Incognitee Api at " + url + " for shard " + shard,
       );
       this.shard = shard;
-      const worker = new IntegriteeWorker(url, {
-        createWebSocket: (url) => new WebSocket(url),
-        types: {},
-      });
+      const worker = new IntegriteeWorker(url);
       this.api = worker;
       const sk = await worker.getShardVault();
       this.vault = encodeAddress(sk[0]);


### PR DESCRIPTION
We only have to overwrite the websocket factory method for our integration tests to allow self signed certificates