### PR TITLE
[chrome] fix occasional long timeouts and loss of websocket connection due to heavy throttling of background trabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "vue-router": "^4.3.2"
   },
   "dependencies": {
-    "@encointer/util": "^0.18.1",
-    "@encointer/worker-api": "^0.18.1",
+    "@encointer/util": "^0.18.2",
+    "@encointer/worker-api": "^0.18.2",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@headlessui/tailwindcss": "^0.2.1",
     "@headlessui/vue": "^1.7.22",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -814,6 +814,13 @@ async function reconnectShieldingTargetIfNecessary() {
     );
     shieldingTargetApi.value = await ApiPromise.create({ provider: wsProvider });
     await shieldingTargetApi.value.isReady;
+
+    // await is quick as we only subscribe
+    await shieldingTargetApi.value.rpc.chain.subscribeNewHeads((lastHeader) => {
+      systemHealth.observeShieldingTargetBlockNumber(
+          lastHeader.number.toNumber(),
+      );
+    });
   }
 }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -746,7 +746,7 @@ async function onVisible() {
 
   if (!incogniteeStore.api?.isConnected) {
     console.debug("[onVisible] Reconnecting to the worker api");
-    await incogniteeStore.api?.connect();
+    await incogniteeStore.api?.reconnect();
   }
 
   // avoid spamming polls due to visibility changes
@@ -768,7 +768,14 @@ async function onBackground() {
 
 async function closeWs() {
   console.debug("closing websocket");
-  await incogniteeStore.api?.closeWs();
+  if (incogniteeStore.api?.isConnected) {
+    // not sure why, but sometimes the websocket is already
+    // closed here.
+    await incogniteeStore.api?.closeWs();
+    console.debug("closed websocket");
+  } else {
+    console.debug("websocket was closed already");
+  }
 }
 
 watch(

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -218,6 +218,10 @@ const fetchIncogniteeBalance = async () => {
     return;
   }
 
+  if (!incogniteeStore.api?.isConnected) {
+    await incogniteeStore.api?.reconnect();
+  }
+
   isUpdatingIncogniteeBalance.value = true;
 
   const injector = accountStore.hasInjector ? accountStore.injector : null;
@@ -314,6 +318,9 @@ const fetchNetworkStatus = async () => {
     promises.push(p);
   }
   if (!incogniteeStore.apiReady) return;
+  if (!incogniteeStore.api?.isConnected) {
+    await incogniteeStore.api?.reconnect();
+  }
   console.debug("fetch network status info");
   const getter = incogniteeStore.api.parentchainsInfoGetter(
     incogniteeShard.value,
@@ -364,6 +371,10 @@ const updateNotes = async () => {
 };
 const fetchNoteBucketsInfo = async () => {
   if (!incogniteeStore.apiReady) return;
+  if (!incogniteeStore.api?.isConnected) {
+    await incogniteeStore.api?.reconnect();
+  }
+
   console.log("fetch note buckets info");
   const getter = incogniteeStore.api.noteBucketsInfoGetter(
     incogniteeStore.shard,
@@ -425,6 +436,11 @@ const fetchIncogniteeNotes = async (
     );
     return;
   }
+
+  if (!incogniteeStore.api?.isConnected) {
+    await incogniteeStore.api?.reconnect();
+  }
+
   const bucketIndex = maybeBucketIndex ? maybeBucketIndex : 0;
   const mapKey = `notesFor:${accountStore.account}:${bucketIndex}`;
   const sessionProxy = accountStore.sessionProxyForRole(
@@ -679,6 +695,10 @@ const fetchIncogniteeNotes = async (
 async function fetchWorkerData() {
   if (!incogniteeStore.api?.isReady) {
     return;
+  }
+
+  if (!incogniteeStore.api?.isConnected) {
+    await incogniteeStore.api?.reconnect();
   }
 
   console.debug(

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -810,15 +810,17 @@ async function reconnectShieldingTargetIfNecessary() {
   if (!shieldingTargetApi.value?.isConnected) {
     const wsProvider = new WsProvider(chainConfigs[shieldingTarget.value].api);
     console.log(
-        "re-initializing api at " + chainConfigs[shieldingTarget.value].api,
+      "re-initializing api at " + chainConfigs[shieldingTarget.value].api,
     );
-    shieldingTargetApi.value = await ApiPromise.create({ provider: wsProvider });
+    shieldingTargetApi.value = await ApiPromise.create({
+      provider: wsProvider,
+    });
     await shieldingTargetApi.value.isReady;
 
     // await is quick as we only subscribe
     await shieldingTargetApi.value.rpc.chain.subscribeNewHeads((lastHeader) => {
       systemHealth.observeShieldingTargetBlockNumber(
-          lastHeader.number.toNumber(),
+        lastHeader.number.toNumber(),
       );
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -497,32 +497,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@encointer/node-api@npm:^0.18.1":
-  version: 0.18.1
-  resolution: "@encointer/node-api@npm:0.18.1"
+"@encointer/node-api@npm:^0.18.2":
+  version: 0.18.2
+  resolution: "@encointer/node-api@npm:0.18.2"
   dependencies:
-    "@encointer/types": "npm:^0.18.1"
+    "@encointer/types": "npm:^0.18.2"
     "@polkadot/api": "npm:^11.2.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d5833f2b946e3861a66280de646c5e2e302ba3e29a5e5182683759a8fe95a2c08e57dc48a9321e1f584d32dc9371e78426c0f2722f4169cbb301bab00dd75b9e
+  checksum: 10c0/5e673535cf156ac5d2571adc6da4f7973d62a481a78995fbc09690cd9d95dac7206bb59de3dfbbea33b2f9ea8115b9a651cb1fd20dd2a624719ec1ffcbf5f23d
   languageName: node
   linkType: hard
 
-"@encointer/types@npm:^0.18.1":
-  version: 0.18.1
-  resolution: "@encointer/types@npm:0.18.1"
+"@encointer/types@npm:^0.18.2":
+  version: 0.18.2
+  resolution: "@encointer/types@npm:0.18.2"
   dependencies:
     "@polkadot/api": "npm:^11.2.1"
     "@polkadot/types": "npm:^11.2.1"
     "@polkadot/types-codec": "npm:^11.2.1"
     "@polkadot/util": "npm:^12.6.2"
-  checksum: 10c0/89a302190ca1411f41f89f43292538a42f984eaaeef337a059ed4b0e542aa233d18be97f1694341e6097795f8d03796c9b269713fb3d30265daf6fc457c6e8e5
+  checksum: 10c0/958d95ad350ae40dab69119aef335970f73d81e790a42963997da8dcd808a3fd0a7922e5fe9af34f6bc19246008be2ea3f8ab9ff773b6ff516731d063fb2e633
   languageName: node
   linkType: hard
 
-"@encointer/util@npm:^0.18.1":
-  version: 0.18.1
-  resolution: "@encointer/util@npm:0.18.1"
+"@encointer/util@npm:^0.18.2":
+  version: 0.18.2
+  resolution: "@encointer/util@npm:0.18.2"
   dependencies:
     "@babel/runtime": "npm:^7.18.9"
     "@polkadot/util": "npm:^12.6.2"
@@ -530,17 +530,17 @@ __metadata:
     "@types/bn.js": "npm:^5.1.5"
     assert: "npm:^2.0.0"
     bn.js: "npm:^5.2.1"
-  checksum: 10c0/c71d52c08cdd3b36ef2fdedf2a2cfff6e7c8771dc26acbdbbffee67408c3e062feb6fe986bcac6f104fe7cecf068b5271c02823f1727a6a0eccbbfb978b08f88
+  checksum: 10c0/432de262dc3f80955f2b29f55ba546e19e1aa6306b23e8d11710436c5e774e4b758c8886fc1f52ea5ab45edd4f4098d625a3b76a792482e271d3be043373789c
   languageName: node
   linkType: hard
 
-"@encointer/worker-api@npm:^0.18.1":
-  version: 0.18.1
-  resolution: "@encointer/worker-api@npm:0.18.1"
+"@encointer/worker-api@npm:^0.18.2":
+  version: 0.18.2
+  resolution: "@encointer/worker-api@npm:0.18.2"
   dependencies:
-    "@encointer/node-api": "npm:^0.18.1"
-    "@encointer/types": "npm:^0.18.1"
-    "@encointer/util": "npm:^0.18.1"
+    "@encointer/node-api": "npm:^0.18.2"
+    "@encointer/types": "npm:^0.18.2"
+    "@encointer/util": "npm:^0.18.2"
     "@peculiar/webcrypto": "npm:^1.4.6"
     "@polkadot/api": "npm:^11.2.1"
     "@polkadot/keyring": "npm:^12.6.2"
@@ -555,7 +555,7 @@ __metadata:
     tslib: "npm:^2.6.2"
   peerDependencies:
     "@polkadot/x-randomvalues": ^12.3.2
-  checksum: 10c0/6a6e7a6bf5120e8ec2bcad830c0d9069e36bcd427c672eaf28b358463980604dda8546ee74ae7950e820e84592e97aa7e0231e6f4ac832f4584fa543ecb3c5bb
+  checksum: 10c0/ee8d0435a5a6d7f96184ae3e7cdcefd508fa4ca72baf03b35326d2897144dac4214bb12dff2d7634ad2e6db2adf3316bfa9b75ba94846db0b45894e0f2d486e1
   languageName: node
   linkType: hard
 
@@ -9655,8 +9655,8 @@ __metadata:
   resolution: "nuxt-app@workspace:."
   dependencies:
     "@egoist/tailwindcss-icons": "npm:^1.0.0"
-    "@encointer/util": "npm:^0.18.1"
-    "@encointer/worker-api": "npm:^0.18.1"
+    "@encointer/util": "npm:^0.18.2"
+    "@encointer/worker-api": "npm:^0.18.2"
     "@esbuild-plugins/node-globals-polyfill": "npm:^0.2.3"
     "@headlessui/tailwindcss": "npm:^0.2.1"
     "@headlessui/vue": "npm:^1.7.22"


### PR DESCRIPTION
We detect now if the browser goes into background, and stop polling the getters in this case. Additionally, we manually close the websocket after 20 seconds (this prevents unexpected closed errors). When we come into foreground again, we open a new websocket connection with the worker's new `reconnect` method. Note: if we were connected once, and lose the connection, we have to call `reconnect` on the `worker` instead of `connect`, connect will fail (this is a bit confusing to me, but it seems to be the standard of websockets).

* Closes #121
* Closes #113 

Issues:
- I don't understand yet how to stop polling the notes when in the background (as I don't understand vue yet)
- Under some circumstances (e.g. low user interaction), chrome might throttle even while being in the foreground. We could take some additional measures to detect that too. However, I made the practical approach now, and just put some connection checks, and reconnect as a safety measure in case we still lose a connection sometimes. So we might still see occasional websocket closed errors, but we should recover immediately from it.
- In the future, we should probably make the worker have automatic websocket disconnect detection and establish reconnection, so that the front-end does not have to care about that, see https://github.com/encointer/encointer-js/issues/129