### PR TITLE
Refactor code to be able to handle internal private fields of the worker and fix some warnings

### DIFF
--- a/components/overlays/SessionProxiesOverlay.vue
+++ b/components/overlays/SessionProxiesOverlay.vue
@@ -211,6 +211,7 @@ import {
   asset,
   incogniteeChainNativeAsset,
 } from "~/lib/environmentConfig";
+import type {AddressOrPair} from "@polkadot/api-base/types";
 
 const accountStore = useAccount();
 const incogniteeStore = useIncognitee();
@@ -280,7 +281,7 @@ const addSessionProxyFromSeed = async (seed: Uint8Array) => {
     name: "fresh",
   });
   const injector = accountStore.hasInjector ? accountStore.injector : null;
-  const role = incogniteeStore.api.createType(
+  const role = incogniteeStore.createType(
     "SessionProxyRole",
     selectedSessionProxyRole.value,
   );
@@ -299,9 +300,9 @@ const addSessionProxyFromSeed = async (seed: Uint8Array) => {
     new TypeRegistry(),
     accountStore.nonce[incogniteeSidechain.value],
   );
-  await incogniteeStore.api
+  await incogniteeStore.getWorker()
     .trustedAddSessionProxy(
-      accountStore.account,
+      accountStore.getCurrentAccount,
       incogniteeStore.shard,
       incogniteeStore.fingerprint,
       role,
@@ -345,9 +346,9 @@ const modifySessionProxyRole = async (
     new TypeRegistry(),
     accountStore.nonce[incogniteeSidechain.value],
   );
-  await incogniteeStore.api
+  await incogniteeStore.getWorker()
     .trustedAddSessionProxy(
-      accountStore.account,
+      accountStore.getCurrentAccount,
       incogniteeStore.shard,
       incogniteeStore.fingerprint,
       role,

--- a/components/tabs/MessagingTab.vue
+++ b/components/tabs/MessagingTab.vue
@@ -661,7 +661,7 @@ const submitSendForm = () => {
 const sendPrivately = async () => {
   console.log("sending message on incognitee");
   txStatus.value = "⌛ Sending message privately on incognitee";
-  const account = accountStore.account;
+  const account = accountStore.getCurrentAccount;
   if (
     accountStore.getDecimalBalanceTransferable(incogniteeChainAssetId.value) <
       3 * txFeeBase(asset.value) &&
@@ -685,6 +685,13 @@ const sendPrivately = async () => {
     return;
   }
   const note = sendPrivateNote.value.length > 0 ? sendPrivateNote.value : null;
+  if (note == null) {
+    alert(
+        "Please enter a message to send privately",
+    );
+    return;
+  }
+
   const nonce = new u32(
     new TypeRegistry(),
     accountStore.nonce[incogniteeSidechain.value],
@@ -693,7 +700,7 @@ const sendPrivately = async () => {
     `sending message from ${account.address} privately to ${conversationAddress.value} with nonce ${nonce} and note: ${note}`,
   );
 
-  await incogniteeStore.api
+  await incogniteeStore.getWorker()
     .trustedSendNote(
       account,
       incogniteeStore.shard,

--- a/components/tabs/VouchersTab.vue
+++ b/components/tabs/VouchersTab.vue
@@ -488,7 +488,7 @@ const fundNewVoucher = async () => {
     sendAmount.value,
     incogniteeChainAssetId.value,
   );
-  const account = accountStore.account;
+  const account = accountStore.getCurrentAccount;
   const encoder = new TextEncoder();
   const byteLength = encoder.encode(sendPrivateNote.value).length;
   // fixme: https://github.com/encointer/encointer-js/issues/123
@@ -510,14 +510,14 @@ const fundNewVoucher = async () => {
   );
 
   if (asset.value) {
-    await incogniteeStore.api
+    await incogniteeStore.getWorker()
       .trustedAssetTransfer(
         account,
         incogniteeStore.shard,
         incogniteeStore.fingerprint,
         accountStore.getAddress,
         voucher.address,
-        amount,
+        amount.toNumber(),
         asset.value,
         note,
         {
@@ -531,14 +531,14 @@ const fundNewVoucher = async () => {
       )
       .catch((err) => handleTopError(err));
   } else {
-    await incogniteeStore.api
+    await incogniteeStore.getWorker()
       .trustedBalanceTransfer(
         account,
         incogniteeStore.shard,
         incogniteeStore.fingerprint,
         accountStore.getAddress,
         voucher.address,
-        amount,
+        amount.toNumber(),
         note,
         {
           signer: accountStore.injector?.signer,
@@ -555,10 +555,10 @@ const fundNewVoucher = async () => {
 };
 
 const generateNewVoucher = async (
-  amount: BigInt,
+  amount: bigint,
   shard: string,
   note: string | null,
-): Voucher => {
+): Promise<Voucher> => {
   return cryptoWaitReady().then(() => {
     const generatedMnemonic = mnemonicGenerate();
     const localKeyring = new Keyring({ type: "sr25519", ss58Format: 42 });

--- a/components/tabs/WalletTab.vue
+++ b/components/tabs/WalletTab.vue
@@ -1472,7 +1472,7 @@ const unshield = async () => {
         incogniteeStore.fingerprint,
         accountStore.getAddress,
         unshieldingRecipientAddress.value,
-        amount.toNumber(),
+        amount,
         {
           signer: accountStore.injector?.signer,
           delegate: accountStore.sessionProxyForRole(SessionProxyRole.Any),

--- a/components/tabs/WalletTab.vue
+++ b/components/tabs/WalletTab.vue
@@ -1169,19 +1169,20 @@ import {
   ChainAssetId,
   unifyAssetId,
 } from "../../configs/assets";
+import type {GuessTheNumberInfo} from "@encointer/types";
 
 const accountStore = useAccount();
 const incogniteeStore = useIncognitee();
 const systemHealth = useSystemHealth();
 const isSignerBusy = ref(false);
-const sendAmount = ref(null);
+const sendAmount = ref<number | null>(null);
 const sendPrivateNote = ref("");
 const shieldAmount = ref(11.0);
 const unshieldAmount = ref(10.0);
 const recipientAddress = ref("");
 const unshieldingRecipientAddress = ref("");
 const guess = ref(null);
-const guessTheNumberInfo = ref(null);
+const guessTheNumberInfo = ref<GuessTheNumberInfo | null>(null);
 const currentTab = ref("public");
 const txStatus = ref("");
 const faucetUrl = ref(null);
@@ -1432,7 +1433,7 @@ const unshield = async () => {
     unshieldAmount.value,
     incogniteeChainAssetId.value,
   );
-  const account = accountStore.account;
+  const account = accountStore.getCurrentAccount;
   const nonce = new u32(
     new TypeRegistry(),
     accountStore.nonce[incogniteeSidechain.value],
@@ -1441,7 +1442,7 @@ const unshield = async () => {
     `sending ${unshieldAmount.value} ${accountStore.getSymbol(asset.value)} from ${accountStore.getAddress} publicly (nonce:${nonce}) to ${unshieldingRecipientAddress.value} on L1 (shard: ${incogniteeStore.shard})`,
   );
   if (asset.value) {
-    await incogniteeStore.api
+    await incogniteeStore.getWorker()
       .assetUnshieldFunds(
         account,
         incogniteeStore.shard,
@@ -1464,14 +1465,14 @@ const unshield = async () => {
       )
       .catch((err) => handleTopError(err));
   } else {
-    await incogniteeStore.api
+    await incogniteeStore.getWorker()
       .balanceUnshieldFunds(
         account,
         incogniteeStore.shard,
         incogniteeStore.fingerprint,
         accountStore.getAddress,
         unshieldingRecipientAddress.value,
-        amount,
+        amount.toNumber(),
         {
           signer: accountStore.injector?.signer,
           delegate: accountStore.sessionProxyForRole(SessionProxyRole.Any),
@@ -1492,11 +1493,16 @@ const unshield = async () => {
 const sendPrivately = async () => {
   console.log("sending funds on incognitee");
   txStatus.value = "⌛ Sending funds privately on Incognitee.";
+  if (!sendAmount.value) {
+    alert("Please enter an amount to send.");
+    return;
+  }
+
   const amount = accountStore.decimalAmountToBigInt(
-    sendAmount.value,
+    sendAmount.value!,
     incogniteeChainAssetId.value,
   );
-  const account = accountStore.account;
+  const account = accountStore.getCurrentAccount;
 
   const encoder = new TextEncoder();
   const byteLength = encoder.encode(sendPrivateNote.value).length;
@@ -1517,7 +1523,7 @@ const sendPrivately = async () => {
   );
 
   if (asset.value) {
-    await incogniteeStore.api
+    await incogniteeStore.getWorker()
       .trustedAssetTransfer(
         account,
         incogniteeStore.shard,
@@ -1538,7 +1544,7 @@ const sendPrivately = async () => {
       )
       .catch((err) => handleTopError(err));
   } else {
-    await incogniteeStore.api
+    await incogniteeStore.getWorker()
       .trustedBalanceTransfer(
         account,
         incogniteeStore.shard,
@@ -1561,18 +1567,23 @@ const sendPrivately = async () => {
   //todo: manually inc nonce locally avoiding clashes with fetchIncogniteeBalance
 };
 const submitGuess = async () => {
+  if (!guess.value) {
+    alert("Please enter a guess");
+    return;
+  }
+
   console.log("submit guess: ", guess.value);
   txStatus.value = "⌛ Privately submitting your guess to Incognitee.";
-  const account = accountStore.account;
+  const account = accountStore.getCurrentAccount;
   const nonce = new u32(
     new TypeRegistry(),
     accountStore.nonce[incogniteeSidechain.value],
   );
   console.log(
-    `sending guess ${guess.value} from ${account.address} privately to incognitee`,
+    `sending guess ${guess.value} from ${account} privately to incognitee`,
   );
 
-  await incogniteeStore.api
+  await incogniteeStore.getWorker()
     .guessTheNumber(
       account,
       incogniteeStore.shard,
@@ -1593,7 +1604,7 @@ const submitGuess = async () => {
 const fetchGuessTheNumberInfo = async () => {
   if (!incogniteeStore.apiReady) return;
   console.log("fetch guess the number info");
-  const getter = incogniteeStore.api.guessTheNumberInfoGetter(
+  const getter = incogniteeStore.getWorker().guessTheNumberInfoGetter(
     incogniteeStore.shard,
   );
   await getter.send().then((info) => {
@@ -1739,7 +1750,7 @@ const openPrivateSendOverlay = () => {
   );
   sendAmount.value = Math.floor(
     Math.min(
-      sendAmount.value,
+      sendAmount.value!,
       accountStore.getDecimalBalanceFree(incogniteeChainAssetId.value) -
         txFeeBase(asset.value),
     ),

--- a/configs/chains.ts
+++ b/configs/chains.ts
@@ -16,8 +16,9 @@ export enum ChainId {
 
 type ChainConfig = {
   name: string;
-  api: string;
+  api: string[];
   faucetUrl?: string;
+  indexerUrls?: string[]
 };
 
 export const chainConfigs: Record<ChainId, ChainConfig> = {
@@ -82,24 +83,24 @@ export const chainConfigs: Record<ChainId, ChainConfig> = {
   },
   [ChainId.IntegriteePaseo]: {
     name: "Integritee Paseo",
-    api: "wss://paseo.api.integritee.network",
+    api: ["wss://paseo.api.integritee.network"],
     faucetUrl: "https://substratefaucet.xyz/integritee/ADDRESS",
   },
   [ChainId.IntegriteeDev]: {
     name: "Integritee Dev",
-    api: "ws://localhost:9944",
+    api: ["ws://localhost:9944"],
   },
   [ChainId.IncogniteeAssetHubPaseo]: {
     name: "Incognitee Asset Hub Paseo",
-    api: "wss://scv1.asset-hub-paseo.api.incognitee.io:443",
+    api: ["wss://scv1.asset-hub-paseo.api.incognitee.io:443"],
   },
   [ChainId.IncogniteeIntegriteeKusama]: {
     name: "Incognitee Integritee Kusama",
-    api: "wss://scv1.integritee-kusama.api.incognitee.io:443",
+    api: ["wss://scv1.integritee-kusama.api.incognitee.io:443"],
   },
   [ChainId.IncogniteeAssetHubPolkadot]: {
     name: "Incognitee Asset Hub Polkadot",
-    api: "wss://scv1.asset-hub-polkadot.api.incognitee.io:443",
+    api: ["wss://scv1.asset-hub-polkadot.api.incognitee.io:443"],
   },
 };
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -129,7 +129,7 @@ import WalletTab from "~/components/tabs/WalletTab.vue";
 import VouchersTab from "~/components/tabs/VouchersTab.vue";
 import ChooseWalletOverlay from "~/components/overlays/ChooseWalletOverlay.vue";
 import SessionProxiesOverlay from "~/components/overlays/SessionProxiesOverlay.vue";
-import { computed, onMounted, onUnmounted, ref, watch, defineProps } from "vue";
+import {computed, onMounted, onUnmounted, ref, watch, defineProps, markRaw} from "vue";
 import { chainConfigs } from "@/configs/chains.ts";
 import { useAccount } from "@/store/account.ts";
 import { useIncognitee } from "@/store/incognitee.ts";
@@ -693,13 +693,13 @@ async function reconnectShieldingTargetIfNecessary() {
     console.log(
       "re-initializing api at " + chainConfigs[shieldingTarget.value].api,
     );
-    shieldingTargetApi.value = await ApiPromise.create({
+    shieldingTargetApi.value = markRaw(await ApiPromise.create({
       provider: wsProvider,
-    });
-    await shieldingTargetApi.value.isReadyOrError;
+    }));
+    await shieldingTargetApi.value!.isReadyOrError;
 
     // await is quick as we only subscribe
-    await shieldingTargetApi.value.rpc.chain.subscribeNewHeads((lastHeader) => {
+    await shieldingTargetApi.value!.rpc.chain.subscribeNewHeads((lastHeader) => {
       systemHealth.observeShieldingTargetBlockNumber(
         lastHeader.number.toNumber(),
       );
@@ -718,7 +718,8 @@ const subscribeWhatsReady = async () => {
   console.log(
     "trying to init api at " + chainConfigs[shieldingTarget.value].api,
   );
-  shieldingTargetApi.value = await ApiPromise.create({ provider: wsProvider });
+  // need to mark it as raw to keep access to private fields
+  shieldingTargetApi.value = markRaw(await ApiPromise.create({ provider: wsProvider }));
   await shieldingTargetApi.value.isReadyOrError;
   accountStore.setExistentialDeposit(
     shieldingTargetApi.value.consts.balances.existentialDeposit.toBigInt(),

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -672,10 +672,10 @@ async function onBackground() {
 
 async function closeWs() {
   console.debug("closing websocket");
-  if (incogniteeStore.api?.isConnected) {
+  if (incogniteeStore.isConnected()) {
     // not sure why, but sometimes the websocket is already
     // closed here.
-    await incogniteeStore.api?.closeWs();
+    await incogniteeStore.getWorker().closeWs();
     console.debug("closed websocket");
   } else {
     console.debug("websocket was closed already");

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -456,7 +456,7 @@ const bucketsCount = computed(() => {
 const unfetchedBucketsCount = computed(() => {
   if (!noteBucketsInfo.value) {
     console.log("[unfetchedBucketsCount] no note buckets info");
-    return null;
+    return 0;
   }
   // If we want to use methods of the polkadot-js type, we have to
   // remove vue's proxy which makes private fields unavailable.

--- a/store/account.ts
+++ b/store/account.ts
@@ -43,6 +43,13 @@ export const useAccount = defineStore("account", {
     existentialDeposit: <Record<string, BigInt>>{},
   }),
   getters: {
+    getAccount({ account }): string {
+      if (!account) {
+        throw new Error("No account set");
+      }
+      // Todo: we should use string in the first place as we infer string anywhere, but this is a workaround for now.
+      return account as string;
+    },
     getShortAddress({ account }): string {
       if (!account) return "none";
       const address = asString(account as AddressOrPair);

--- a/store/account.ts
+++ b/store/account.ts
@@ -11,6 +11,10 @@ import {
   sessionProxyRoleOrder,
 } from "@/lib/sessionProxyStorage.ts";
 
+let currentAccount : AddressOrPair | null = null;
+
+type AccountInstance = InstanceType<typeof AddressOrPair>
+
 export const useAccount = defineStore("account", {
   state: () => ({
     // if we have an external signer, this is an address only. otherwise it should be a pair
@@ -49,6 +53,12 @@ export const useAccount = defineStore("account", {
       }
       // Todo: we should use string in the first place as we infer string anywhere, but this is a workaround for now.
       return account as string;
+    },
+    getCurrentAccount(): AccountInstance {
+      if (!currentAccount) {
+        throw new Error("No account set");
+      }
+      return currentAccount as AddressOrPair
     },
     getShortAddress({ account }): string {
       if (!account) return "none";
@@ -245,6 +255,7 @@ export const useAccount = defineStore("account", {
       this.BalanceFrozen = {};
     },
     setAccount(account: AddressOrPair) {
+      currentAccount = account;
       this.account = account;
     },
     setInjector(injector: InjectedExtension) {

--- a/store/incognitee.ts
+++ b/store/incognitee.ts
@@ -1,46 +1,105 @@
-import { defineStore } from "pinia";
-import { IntegriteeWorker } from "@encointer/worker-api";
-import { encodeAddress } from "@polkadot/keyring";
+import {defineStore} from "pinia";
+import {IntegriteeWorker} from "@encointer/worker-api";
+import {encodeAddress} from "@polkadot/keyring";
 import bs58 from "bs58";
-import { hexToU8a } from "@polkadot/util";
+import {hexToU8a} from "@polkadot/util";
+
+// Non-reactive singleton worker instance
+let worker: IntegriteeWorker | null = null;
+
+// Type helper: public instance type of IntegriteeWorker
+// This helps the IDEs with autocompletion and type checking.
+type WorkerInstance = InstanceType<typeof IntegriteeWorker>;
+
 export const useIncognitee = defineStore("incognitee", {
-  state: () => ({
-    api: <IntegriteeWorker | null>null,
-    apiReady: false,
-    shard: "",
-    fingerprint: "",
-    vault: "",
-  }),
-  getters: {
-    getShard(): string {
-      return this.shard;
+    state: () => ({
+        api: <IntegriteeWorker | null>null,
+        apiReady: false,
+        shard: "",
+        fingerprint: "",
+        vault: "",
+    }),
+    getters: {
+        getShard(): string {
+            return this.shard;
+        },
+        getFingerprint(): string {
+            return this.fingerprint;
+        },
+        getVault(): string {
+            return this.vault;
+        },
     },
-    getFingerprint(): string {
-      return this.fingerprint;
+    actions: {
+        async initializeApi(url: string[], shard: string) {
+            console.log(
+                "Initializing Incognitee Api at " + url + " for shard " + shard,
+            );
+
+            this.shard = shard;
+            worker = new IntegriteeWorker(url);
+
+            const sk = await worker.getShardVault();
+            this.vault = encodeAddress(sk[0]);
+            console.log("  Vault: " + this.vault);
+
+            const fingerprint_hex = await worker.getFingerprint();
+            this.fingerprint = bs58.encode(hexToU8a(fingerprint_hex.toString()));
+            console.log(
+                `  validateer at ${url} reported fingerprint: ` + this.fingerprint,
+            );
+
+            //todo: verify fingerprint against teerex
+            this.apiReady = true;
+            console.log("  Incognitee Api connected to sidechain");
+        },
+
+        /** Return the initialized worker instance (typed) */
+        getWorker(): WorkerInstance {
+            if (!worker) {
+                throw new Error("API not initialized");
+            }
+            return worker;
+        },
+
+        /** Do something with the worker while ensuring that it is initialized and connected. */
+        async withWorker<T>(fn: (worker: WorkerInstance) => T): Promise<T> {
+            if (!worker) {
+                throw new Error('Worker not initialized');
+            }
+
+            await worker.isReady()
+
+            if (!worker.isConnected) {
+                await worker.reconnect();
+            }
+
+            try {
+                return fn(worker);
+            } catch (err) {
+                console.error('Error in worker interaction:', err);
+                throw err;
+            }
+        },
+        createType(apiType: string, obj?: any): any {
+            if (!worker) {
+                throw new Error('[createType] Worker not initialized');
+            }
+
+            return worker.createType(apiType, obj);
+        },
+        isConnected(): boolean {
+            if (!worker) {
+                console.warn('[isConnected] Worker not initialized');
+                return false
+            }
+            return worker.isConnected;
+        },
+        reconnect(): Promise<void> {
+            if (!worker) {
+                throw new Error('[reconnect] Worker not initialized');
+            }
+            return worker.reconnect();
+        }
     },
-    getVault(): string {
-      return this.vault;
-    },
-  },
-  actions: {
-    async initializeApi(url: string, shard: string) {
-      console.log(
-        "Initializing Incognitee Api at " + url + " for shard " + shard,
-      );
-      this.shard = shard;
-      const worker = new IntegriteeWorker(url);
-      this.api = worker;
-      const sk = await worker.getShardVault();
-      this.vault = encodeAddress(sk[0]);
-      console.log("  Vault: " + this.vault);
-      const fingerprint_hex = await worker.getFingerprint();
-      this.fingerprint = bs58.encode(hexToU8a(fingerprint_hex.toString()));
-      console.log(
-        `  validateer at ${url} reported fingerprint: ` + this.fingerprint,
-      );
-      //todo: verify fingerprint against teerex
-      console.log("  Incognitee Api connected to sidechain");
-      this.apiReady = true;
-    },
-  },
 });

--- a/store/systemHealth.ts
+++ b/store/systemHealth.ts
@@ -9,6 +9,8 @@ class ObservableNumber {
   constructor(value: number) {
     this.value = value;
     this.timestamp = new Date();
+    this.lastDuration = 0;
+    this.lastValue = 0;
   }
   observe(new_value: number) {
     if (new_value === this.value) {
@@ -83,8 +85,8 @@ export const useSystemHealth = defineStore("system-health", {
       shieldingTargetLightClientGenesisHashHex,
     }): SidechainHealth {
       const lag =
-        shieldingTargetLastBlockNumber?.value -
-        shieldingTargetImportedBlockNumber?.value;
+          (shieldingTargetLastBlockNumber?.value ?? 0) -
+          (shieldingTargetImportedBlockNumber?.value ?? 0);
       let importHealth;
       if (lag <= 12) {
         importHealth = Health.Healthy;
@@ -96,12 +98,12 @@ export const useSystemHealth = defineStore("system-health", {
         importHealth = Health.Unknown;
       }
       const targetHealth = parachainBlockAgeToHealth(
-        shieldingTargetLastBlockNumber?.age(),
+        shieldingTargetLastBlockNumber?.age() ?? 0,
       );
       let genesisMatch = Health.Warning;
       if (
-        shieldingTargetApiGenesisHashHex?.length > 0 &&
-        shieldingTargetLightClientGenesisHashHex?.length > 0
+          (shieldingTargetApiGenesisHashHex?.length ?? 0) > 0 &&
+          (shieldingTargetLightClientGenesisHashHex?.length ?? 0) > 0
       ) {
         genesisMatch =
           shieldingTargetApiGenesisHashHex ===
@@ -113,34 +115,34 @@ export const useSystemHealth = defineStore("system-health", {
     },
     getIntegriteeSystemHealth({ integriteeLastBlockNumber }): IntegriteeHealth {
       const progressHealth = parachainBlockAgeToHealth(
-        integriteeLastBlockNumber?.age(),
+        integriteeLastBlockNumber?.age() ?? 0,
       );
       return new IntegriteeHealth(progressHealth);
     },
     getIntergiteeBlockNumberObservable({
       integriteeLastBlockNumber,
     }): ObservableNumber {
-      return integriteeLastBlockNumber;
+      return integriteeLastBlockNumber ?? new ObservableNumber(0);
     },
     getShieldingTargetBlockNumberObservable({
       shieldingTargetLastBlockNumber,
     }): ObservableNumber {
-      return shieldingTargetLastBlockNumber;
+      return shieldingTargetLastBlockNumber ?? new ObservableNumber(0);
     },
     getShieldingTargetImportedBlockNumberObservable({
       shieldingTargetImportedBlockNumber,
     }): ObservableNumber {
-      return shieldingTargetImportedBlockNumber;
+      return shieldingTargetImportedBlockNumber ?? new ObservableNumber(0);
     },
     getShieldingTargetApiGenesisHashHex({
       shieldingTargetApiGenesisHashHex,
     }): string {
-      return shieldingTargetApiGenesisHashHex;
+      return shieldingTargetApiGenesisHashHex ?? "undefined";
     },
     getShieldingTargetLightClientGenesisHashHex({
       shieldingTargetLightClientGenesisHashHex,
     }): string {
-      return shieldingTargetLightClientGenesisHashHex;
+      return shieldingTargetLightClientGenesisHashHex ?? "undefined";
     },
   },
   actions: {

--- a/store/systemHealth.ts
+++ b/store/systemHealth.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ChainId } from "@/configs/chains";
+import {markRaw} from "vue";
 
 class ObservableNumber {
   value: number;
@@ -122,17 +122,17 @@ export const useSystemHealth = defineStore("system-health", {
     getIntergiteeBlockNumberObservable({
       integriteeLastBlockNumber,
     }): ObservableNumber {
-      return integriteeLastBlockNumber ?? new ObservableNumber(0);
+      return integriteeLastBlockNumber ?? markRaw(new ObservableNumber(0));
     },
     getShieldingTargetBlockNumberObservable({
       shieldingTargetLastBlockNumber,
     }): ObservableNumber {
-      return shieldingTargetLastBlockNumber ?? new ObservableNumber(0);
+      return shieldingTargetLastBlockNumber ?? markRaw(new ObservableNumber(0));
     },
     getShieldingTargetImportedBlockNumberObservable({
       shieldingTargetImportedBlockNumber,
     }): ObservableNumber {
-      return shieldingTargetImportedBlockNumber ?? new ObservableNumber(0);
+      return shieldingTargetImportedBlockNumber ?? markRaw(new ObservableNumber(0));
     },
     getShieldingTargetApiGenesisHashHex({
       shieldingTargetApiGenesisHashHex,
@@ -149,21 +149,23 @@ export const useSystemHealth = defineStore("system-health", {
     observeShieldingTargetBlockNumber(block_number: number) {
       this.shieldingTargetLastBlockNumber
         ? this.shieldingTargetLastBlockNumber?.observe(block_number)
-        : (this.shieldingTargetLastBlockNumber = new ObservableNumber(
+        : (this.shieldingTargetLastBlockNumber = markRaw(new ObservableNumber(
             block_number,
-          ));
+          )));
     },
     observeShieldingTargetImportedBlockNumber(block_number: number) {
       this.shieldingTargetImportedBlockNumber
         ? this.shieldingTargetImportedBlockNumber?.observe(block_number)
-        : (this.shieldingTargetImportedBlockNumber = new ObservableNumber(
+        : (this.shieldingTargetImportedBlockNumber = markRaw(new ObservableNumber(
             block_number,
-          ));
+          )));
     },
     observeIntegriteeBlockNumber(block_number: number) {
       this.integriteeLastBlockNumber
         ? this.integriteeLastBlockNumber?.observe(block_number)
-        : (this.integriteeLastBlockNumber = new ObservableNumber(block_number));
+        : (this.integriteeLastBlockNumber = markRaw(new ObservableNumber(
+              block_number,
+          )));
     },
     setShieldingTargetApiGenesisHashHex(genesis_hash_hex: string) {
       this.shieldingTargetApiGenesisHashHex = genesis_hash_hex;


### PR DESCRIPTION
After the update in #142, we got several errors like "Cannot read private field". This is because private fields were introduced in the meantime in JS **and** Vue or Pinia-stores strip them under certain circumstances. This PR fixes the issue by:

* Do not store complex objects in the store if possible (e.g. the worker).
* When handling reactive objects declared with `ref` we do:
  * If we need to pass the object to the UI template, but we don't need reactivity (e.g. shieldingTargetApi), we assign the value like `shieldingTargetApi.value = markRaw(api);`
  * If we need reactivity, we can not mark it as raw, but we can convert them to a raw object before accessing internal private fields e.g. `toRaw(notesBucketInfo)`. Note: simple things like `Option.unwrap()` need internal private state.
  * If we don't need reactivity, nor passing them into a UI-template, variables should just be regular variables.

* Other changes:
  * Fixed bunch of warnings during the debugging phase.

Tested:
* Unshield works (DOT production)
* Private transfer works (DOT production)